### PR TITLE
Add missing SERVER header in M-SEARCH response

### DIFF
--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -183,6 +183,7 @@ var setupServer = function(){
 				ST: headers.ST,
 				"CONFIGID.UPNP.ORG": 7337,
 				"BOOTID.UPNP.ORG": 7337,
+				SERVER: SERVER,
 				USN: "uuid:" + self.uuid + "::" + headers.ST
 			},self.extraHeaders), address);
 		}


### PR DESCRIPTION
According to UPnP Device Architecture 1.1, section 1.3.3, SERVER header
is mandatory in M-SEARCH response.