### PR TITLE
Improvement: https://github.com/fraunhoferfokus/peer-dial/issues/5

### DIFF
--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -34,7 +34,7 @@ var APP_DESC_TEMPLATE = fs.readFileSync(__dirname + '/../xml/app-desc.xml', 'utf
 var DEVICE_DESC_RENDERER = ejs.compile(DEVICE_DESC_TEMPLATE, { open: '{{', close: '}}' });
 var APP_DESC_RENDERER = ejs.compile(APP_DESC_TEMPLATE, { open: '{{', close: '}}' });
 var SERVER = os.type() + "/" + os.release() + " UPnP/1.1 famium/0.0.1";
-var setupServer = function(){
+var setupServer = function(options){
 	var self = this;
 	var pref = self.prefix;
 	var peer = self.ssdpPeer;
@@ -42,6 +42,10 @@ var setupServer = function(){
 	var appStates = ["stopped", "starting", "running"];
 	var app = self.expressApp;
 	app.use(function(req, res, next){
+		if (options.cors_allow_origin) {
+			res.set("Access-Control-Allow-Origin",options.cors_allow_origin);
+			res.set("Access-Control-Allow-Method", "GET, POST, DELETE, OPTIONS");
+		}
 		if (req.is("text/plain") || req.is("text/xml") || req.is("text/json") || req.is("application/xml") || req.is("application/json")) {
 			req.text = '';
 			req.length = 0;
@@ -231,7 +235,7 @@ var DIALServer = function (options) {
 	this.delegate.launchApp = (options.delegate && typeof options.delegate.launchApp == "function")? options.delegate.launchApp: null;
 	this.delegate.stopApp = (options.delegate && typeof options.delegate.stopApp == "function")? options.delegate.stopApp: null;
 	this.ssdpPeer = ssdp.createPeer();
-	setupServer.call(this);
+	setupServer.call(this,options);
 }
 util.inherits(DIALServer, events.EventEmitter);
 


### PR DESCRIPTION
Mechanism to allow CORS headers to be set. `options.cors_allow_origin` should be set to the value that you wish the `Access-Control-Allow-Origin` header to have. E.g. `*`