### PR TITLE
New CORS implementation: https://github.com/fraunhoferfokus/peer-dial/issues/5

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,19 @@ server.listen(PORT,function(){
 });
 ```
 
+When creating the DIAL Server, you can also specify an option to control what Origins are allowed under [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing). By default, CORS is disabled. 
+Set the origins to be allowed by providing a`corsAllowedOrigins` attribute. For example,
+to allow all origins:
+
+    var dialServer = new dial.Server({
+        ...
+        corsAllowedOrigins: true,        // allow all origins
+        ...
+    });
+
+`corsAllowedOrigins` can also be set to a string, a regex, or a function. See the `origin` configuration
+option of the [cors package](https://www.npmjs.com/package/cors) for details.
+
 For DIAL Client usage please have a look to the following example ([test/dial-client.js](test/dial-client.js)). This example contains calls for all interfaces of DIAL Client and DIAL Device, some of them are commented like `dialDevice.stopApp(...)` and `dialClient.stop();`
 
 ```javascript

--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -28,6 +28,7 @@ var events = require('events');
 var http = require('http');
 var URL = require('url');
 var xml2js = require("xml2js");
+var cors = require("cors");
 
 var DEVICE_DESC_TEMPLATE = fs.readFileSync(__dirname + '/../xml/device-desc.xml', 'utf8');
 var APP_DESC_TEMPLATE = fs.readFileSync(__dirname + '/../xml/app-desc.xml', 'utf8');
@@ -52,10 +53,15 @@ var setupServer = function(){
 			next();
 		}
 	});
-	app.get(pref+"/apps",function(req,rsp){
+
+	// enable CORS preflight
+	app.options(pref+"/apps", cors(this.corsOptions.apps));
+	app.options(pref+"/ssdp", cors(this.corsOptions.ssdp));
+	
+	app.get(pref+"/apps",cors(this.corsOptions.apps),function(req,rsp){
 		rsp.sendStatus(204);
 	});
-	app.get(pref+"/apps/:appName",function(req,rsp){
+	app.get(pref+"/apps/:appName",cors(this.corsOptions.apps),function(req,rsp){
 		var baseURL = req.protocol + "://" + (req.hostname || req.ip || self.host)+":"+self.port+pref;
 		var appName = req.params["appName"];
 		var app = self.delegate.getApp.call(req,appName);
@@ -78,7 +84,7 @@ var setupServer = function(){
 			rsp.sendStatus(404);
 		}
 	});
-	app.post(pref+"/apps/:appName",function(req,rsp){
+	app.post(pref+"/apps/:appName",cors(this.corsOptions.apps),function(req,rsp){
 
 		var baseURL = req.protocol + "://" + (req.hostname || req.ip || self.host)+":"+self.port+pref;
 		var appName = req.params["appName"];
@@ -106,7 +112,7 @@ var setupServer = function(){
 			});
 		}
 	});
-	app.post(pref+"/apps/:appName/dial_data",function(req,rsp){
+	app.post(pref+"/apps/:appName/dial_data",cors(this.corsOptions.apps),function(req,rsp){
 		var baseURL = req.protocol + "://" + (req.hostname || req.ip || self.host)+":"+self.port+pref;
 		var appName = req.params["appName"];
 		var app = self.delegate.getApp.call(req,appName);
@@ -122,7 +128,7 @@ var setupServer = function(){
 		}
 	});
 
-	app.delete(pref+"/apps/:appName/:pid",function(req,rsp){
+	app.delete(pref+"/apps/:appName/:pid",cors(this.corsOptions.apps),function(req,rsp){
 		var baseURL = req.protocol + "://" + (req.hostname || req.ip || self.host)+":"+self.port+pref;
 		var appName = req.params["appName"];
 		var pid = req.params["pid"];
@@ -145,7 +151,7 @@ var setupServer = function(){
 			rsp.sendStatus(404);
 		}
 	});
-	app.get(pref+"/ssdp/device-desc.xml",function(req,rsp){
+	app.get(pref+"/ssdp/device-desc.xml",cors(this.corsOptions.ssdp),function(req,rsp){
 		var baseURL = req.protocol + "://" + (req.hostname || req.ip || self.host)+":"+self.port+pref;
 		var xml = DEVICE_DESC_RENDERER({
 			URLBase: baseURL,
@@ -154,8 +160,6 @@ var setupServer = function(){
 			modelName: self.modelName,
 			uuid: self.uuid
 		});
-		rsp.setHeader("Access-Control-Allow-Method", "GET, POST, DELETE, OPTIONS");
-		rsp.setHeader("Access-Control-Expose-Headers", "Location");
 		rsp.setHeader('Content-Type','application/xml');
 		rsp.setHeader('Application-URL', baseURL+"/apps");
 		rsp.send(xml);
@@ -230,6 +234,20 @@ var DIALServer = function (options) {
 	this.delegate.getApp = (options.delegate && typeof options.delegate.getApp == "function")? options.delegate.getApp: null;
 	this.delegate.launchApp = (options.delegate && typeof options.delegate.launchApp == "function")? options.delegate.launchApp: null;
 	this.delegate.stopApp = (options.delegate && typeof options.delegate.stopApp == "function")? options.delegate.stopApp: null;
+
+	var corsAllowOrigins = options.corsAllowOrigins || false;  // no CORS by default
+	this.corsOptions = {
+		apps: {
+			origin: corsAllowOrigins,
+			methods: ['GET','POST','DELETE','OPTIONS'],
+		},
+		ssdp: {
+			origin: corsAllowOrigins,
+			methods: ['GET','POST','DELETE','OPTIONS'],
+			exposedHeaders: ['Location']
+		}
+	}
+	console.log(this.corsOptions)
 	this.ssdpPeer = ssdp.createPeer();
 	setupServer.call(this);
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"node-uuid": "1.4.1",
 		"express": "4.12.4",
         "opn": "2.0.0",
-        "xml2js": "0.4.9"
+        "xml2js": "0.4.9",
+        "cors": "^2.7.1"
 	},
     "repository": "https://github.com/fraunhoferfokus/peer-dial.git",
 	"readmeFilename": "Readme.md",


### PR DESCRIPTION
Revised CORS implementation. Should address previous concerns.

This one only implements CORS on the DIAL server /apps sub-path and on the SSDP device description.

It now uses the [cors](https://github.com/fraunhoferfokus/peer-dial/issues/5) library. This is a more complete implementation that complies with the requirement that CORS headers are not included unless the request includes CORS headers.