### PR TITLE
Add DialDevice method getAppInfoXml, to return original app XML as a string.

### DIFF
--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -424,7 +424,7 @@ var DialDevice = function (deviceInfo) {
     }
 };
 
-DialDevice.prototype.getAppInfo = function (appName, callback) {
+DialDevice.prototype.getAppInfoXml = function (appName, callback) {
     var appUrl = this.applicationUrl && appName && (this.applicationUrl+"/"+appName) || null;
     if(!appUrl){
         var err = new Error("DIAL appName and DIAL Application-URL cannot be empty for getAppInfo");
@@ -439,27 +439,7 @@ DialDevice.prototype.getAppInfo = function (appName, callback) {
                 appInfoXml += chunk;
             });
             res.on('end', function () {
-                xml2js.parseString(appInfoXml, {
-                    trim: true,
-                    explicitArray: false,
-                    mergeAttrs: true,
-                    explicitRoot: false,
-                    tagNameProcessors: [function(tagName){
-                        tagName = tagName.substr(tagName.indexOf(":")+1);
-                        return tagName;
-                    }],
-                    attrNameProcessors: [function(attrName){
-                        attrName = attrName.substr(attrName.indexOf(":")+1);
-                        return attrName;
-                    }]
-                },function (err, appInfo) {
-                    if(err){
-                        callback(null,err);
-                    }
-                    else {
-                        callback(appInfo);
-                    }
-                });
+                callback(appInfoXml);
             });
         }
         else {
@@ -469,6 +449,36 @@ DialDevice.prototype.getAppInfo = function (appName, callback) {
         }
     }).on('error', function(err) {
         callback && callback(null,err);
+    });
+};
+
+DialDevice.prototype.getAppInfo = function (appName, callback) {
+    this.getAppInfoXml(appName,function(appInfoXml, err) {
+        if (!appInfoXml || err) {
+            callback(null,err);
+        } else {
+            xml2js.parseString(appInfoXml, {
+                trim: true,
+                explicitArray: false,
+                mergeAttrs: true,
+                explicitRoot: false,
+                tagNameProcessors: [function(tagName){
+                    tagName = tagName.substr(tagName.indexOf(":")+1);
+                    return tagName;
+                }],
+                attrNameProcessors: [function(attrName){
+                    attrName = attrName.substr(attrName.indexOf(":")+1);
+                    return attrName;
+                }]
+            },function (err, appInfo) {
+                if(err){
+                    callback(null,err);
+                }
+                else {
+                    callback(appInfo);
+                }
+            });
+        }
     });
 };
 


### PR DESCRIPTION
This adds a separate getAppInfoXml method to DialDevice, as the current getAppInfo methods strips XML namespace info from the application info, and having access to the original XML is useful in itself.

This also changes getAppInfo to be implemented in terms of getAppInfoXml, to avoid duplication.