### PR TITLE
Fix ssdp close in DIALServer.stop being called before ssdp byes sent.

### DIFF
--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -29,6 +29,7 @@ var http = require('http');
 var URL = require('url');
 var xml2js = require('xml2js');
 var cors = require('cors');
+var gate = require('gate');
 
 var DEVICE_DESC_TEMPLATE = fs.readFileSync(__dirname + '/../xml/device-desc.xml', 'utf8');
 var APP_DESC_TEMPLATE = fs.readFileSync(__dirname + '/../xml/app-desc.xml', 'utf8');
@@ -271,8 +272,9 @@ DIALServer.prototype.stop = function(){
 	var pref = self.prefix;
 	var serviceTypes = ["urn:dial-multiscreen-org:service:dial:1","urn:dial-multiscreen-org:device:dial:1","upnp:rootdevice","ssdp:all","uuid:"+self.uuid];
 	//var location = "http://"+self.host+":"+self.port+pref+"/ssdp/device-desc.xml";
-    var location = "http://{{networkInterfaceAddress}}:"+self.port+pref+"/ssdp/device-desc.xml";
-    var peer = self.ssdpPeer;
+	var location = "http://{{networkInterfaceAddress}}:"+self.port+pref+"/ssdp/device-desc.xml";
+	var peer = self.ssdpPeer;
+	var g = gate.create();
 	for (var i = 0; i < serviceTypes.length; i++) {
 		var st = serviceTypes[i];
 		peer.byebye(merge({
@@ -280,9 +282,11 @@ DIALServer.prototype.stop = function(){
 			USN: "uuid:" + self.uuid + "::"+st,
 			SERVER: SERVER,
 			LOCATION: location
-		},self.extraHeaders));
+		},self.extraHeaders), g.latch());
 	};
-	self.ssdpPeer.close();
+	g.await(function() {
+		self.ssdpPeer.close();
+	});
 };
 
 var DIALClient = function (options) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"express": "4.12.4",
 		"opn": "2.0.0",
 		"xml2js": "0.4.9",
-		"cors": "^2.7.1"
+		"cors": "^2.7.1",
+		"gate": "^0.3.0"
 	},
 	"repository": "https://github.com/fraunhoferfokus/peer-dial.git"
 }


### PR DESCRIPTION
At the moment  DIALServer.prototype.stop calls self.ssdpPeer.close() immediately, so the SSDP byebyes which would otherwise be sent by the peer.byebye() calls are never sent.
Instead delay the call to self.ssdpPeer.close() until all peer.byebye() calls have completed.