### PR TITLE
Add application/x-www-form-urlencoded to support Chrome for non-mobile

### DIFF
--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -44,7 +44,7 @@ var setupServer = function(){
 	var appStates = ["stopped", "starting", "running"];
 	var app = self.expressApp;
 	app.use(function(req, res, next){
-		if (req.is("text/plain") || req.is("text/xml") || req.is("text/json") || req.is("application/xml") || req.is("application/json")) {
+		if (req.is("text/plain") || req.is("text/xml") || req.is("text/json") || req.is("application/xml") || req.is("application/json") || req.is("application/x-www-form-urlencoded")) {
 			req.text = '';
 			req.length = 0;
 			req.setEncoding('utf8');


### PR DESCRIPTION
This patch resolves the difference of content-type used by YouTube running on Chrome for non-mobile devices (i.e. PC)