### PR TITLE
Ensure setEncoding only applies to routes beginning with prefix

### DIFF
--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -43,7 +43,7 @@ var setupServer = function(){
 	var serviceTypes = ["urn:dial-multiscreen-org:service:dial:1","urn:dial-multiscreen-org:device:dial:1","upnp:rootdevice","ssdp:all","uuid:"+self.uuid];
 	var appStates = ["stopped", "starting", "running"];
 	var app = self.expressApp;
-	app.use(function(req, res, next){
+	app.use(pref, function(req, res, next){
 		if (req.is("text/plain") || req.is("text/xml") || req.is("text/json") || req.is("application/xml") || req.is("application/json") || req.is("application/x-www-form-urlencoded")) {
 			req.text = '';
 			req.length = 0;


### PR DESCRIPTION
When using as part of a larger express app, that uses https://github.com/expressjs/body-parser this error is encountered: https://github.com/expressjs/body-parser#stream-encoding-should-not-be-set

The change here ensures that setEncoding() is only applied to routes beginning with the `prefix` that is passed to `DIALServer`.