### PR TITLE
Update dependencies

### DIFF
--- a/lib/peer-dial.js
+++ b/lib/peer-dial.js
@@ -18,7 +18,7 @@
  * AUTHORS: Louay Bassbouss (louay.bassbouss@fokus.fraunhofer.de)
  *
  ******************************************************************************/
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var ssdp = require('peer-ssdp');
 var fs = require('fs');
 var ejs = require('ejs');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "peer-dial",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,9 +108,9 @@
 			"dev": true
 		},
 		"ejs": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ=="
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -464,9 +464,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 		},
 		"vary": {
 			"version": "1.1.2",
@@ -474,18 +474,18 @@
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"xml2js": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"version": "0.4.21",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.21.tgz",
+			"integrity": "sha512-gHRSAYBSA1JNVbLV2l8mTpQ/zTLcNtyG4YZmNlA3pjMWTgv9swW9muK55cr3fUmSOezLTR24iPQ+FqxilTvppw==",
 			"requires": {
 				"sax": ">=0.6.0",
-				"xmlbuilder": "~9.0.1"
+				"xmlbuilder": "~13.0.0"
 			}
 		},
 		"xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+			"integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,546 +1,491 @@
 {
 	"name": "peer-dial",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"accepts": {
-			"version": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-			"integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+			"dev": true,
 			"requires": {
-				"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-				"negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
 			}
 		},
-		"array-find-index": {
-			"version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+			"dev": true
 		},
-		"builtin-modules": {
-			"version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-		},
-		"camelcase": {
-			"version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-		},
-		"camelcase-keys": {
-			"version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+		"body-parser": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+			"dev": true,
 			"requires": {
-				"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-				"map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+				"bytes": "3.1.0",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
+				"on-finished": "~2.3.0",
+				"qs": "6.7.0",
+				"raw-body": "2.4.0",
+				"type-is": "~1.6.17"
 			}
+		},
+		"bytes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+			"dev": true
 		},
 		"content-disposition": {
-			"version": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
-			"integrity": "sha1-QoT+auBjCHRjnkToCkGMKTQTXp4="
-		},
-		"content-type": {
-			"version": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-			"integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
-		},
-		"cookie": {
-			"version": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-			"integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
-		},
-		"cookie-signature": {
-			"version": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-		},
-		"cors": {
-			"version": "https://registry.npmjs.org/cors/-/cors-2.8.1.tgz",
-			"integrity": "sha1-YYGqVqu0WiglvjMEcDdHrk6dI4M=",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+			"dev": true,
 			"requires": {
-				"vary": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+				"safe-buffer": "5.1.2"
 			}
 		},
-		"crc": {
-			"version": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
-			"integrity": "sha1-XZyPt3okXNXsopHl0tAFM0urAII="
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
 		},
-		"currently-unhandled": {
-			"version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+		"cookie": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+			"dev": true
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+			"dev": true
+		},
+		"cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
 			"requires": {
-				"array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+				"object-assign": "^4",
+				"vary": "^1"
 			}
 		},
 		"debug": {
-			"version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-			"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
-				"ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+				"ms": "2.0.0"
 			}
-		},
-		"decamelize": {
-			"version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"depd": {
-			"version": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-			"integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
 		},
 		"destroy": {
-			"version": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-			"integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+			"dev": true
 		},
 		"ee-first": {
-			"version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
-			"integrity": "sha1-ag18YiHkkP7v2S7D9EHJzozQl/Q="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
 		},
 		"ejs": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-			"integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
+			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
 		},
-		"error-ex": {
-			"version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"requires": {
-				"is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-			}
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+			"dev": true
 		},
 		"escape-html": {
-			"version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
-			"integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"etag": {
-			"version": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
-			"integrity": "sha1-i8ssavElTEgd/IuZfJBu9ORCwgc=",
-			"requires": {
-				"crc": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
-			}
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"dev": true
 		},
 		"express": {
-			"version": "https://registry.npmjs.org/express/-/express-4.12.4.tgz",
-			"integrity": "sha1-j+wlECVbxrLlgQfEgjnA+jB8GqI=",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+			"dev": true,
 			"requires": {
-				"accepts": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-				"content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
-				"content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-				"cookie": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-				"cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-				"debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-				"depd": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
-				"etag": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
-				"finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz",
-				"fresh": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
-				"merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz",
-				"methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-				"on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
-				"parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-				"path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz",
-				"proxy-addr": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
-				"qs": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-				"range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-				"send": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
-				"serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz",
-				"type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
-				"utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-				"vary": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
-			},
-			"dependencies": {
-				"vary": {
-					"version": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-					"integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
-				}
+				"accepts": "~1.3.7",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
+				"content-type": "~1.0.4",
+				"cookie": "0.4.0",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.1.2",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.1.2",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
 			}
 		},
 		"finalhandler": {
-			"version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz",
-			"integrity": "sha1-2vnEFhsbBuABRmsUEd/baXO+E4s=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+			"dev": true,
 			"requires": {
-				"debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
-				"on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz"
-			}
-		},
-		"find-up": {
-			"version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-			"requires": {
-				"path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
+				"unpipe": "~1.0.0"
 			}
 		},
 		"forwarded": {
-			"version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-			"integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+			"dev": true
 		},
 		"fresh": {
-			"version": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
-			"integrity": "sha1-NYJJkgbJcjcUGQ7ddLRgT+tKYUw="
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+			"dev": true
 		},
 		"gate": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/gate/-/gate-0.3.0.tgz",
 			"integrity": "sha1-mype71dNvM7RBiWQEgY7j5zdMJM="
 		},
-		"get-stdin": {
-			"version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-		},
-		"graceful-fs": {
-			"version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-		},
-		"hosted-git-info": {
-			"version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
-			"integrity": "sha1-SwRF5BwASovRM3dzpP95DKQDGMg="
-		},
-		"indent-string": {
-			"version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+		"http-errors": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+			"dev": true,
 			"requires": {
-				"repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
 			}
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"ipaddr.js": {
-			"version": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
-			"integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+			"dev": true
 		},
-		"is-arrayish": {
-			"version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-		},
-		"is-builtin-module": {
-			"version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"requires": {
-				"builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-			}
-		},
-		"is-finite": {
-			"version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-			}
-		},
-		"is-utf8": {
-			"version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-		},
-		"load-json-file": {
-			"version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"requires": {
-				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-				"parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-				"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-				"strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-			}
-		},
-		"loud-rejection": {
-			"version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"requires": {
-				"currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-				"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-			}
-		},
-		"map-obj": {
-			"version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
 		},
 		"media-typer": {
-			"version": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"meow": {
-			"version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"requires": {
-				"camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-				"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-				"loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-				"map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-				"minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-				"normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-				"read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-				"redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-				"trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-			}
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+			"dev": true
 		},
 		"merge-descriptors": {
-			"version": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz",
-			"integrity": "sha1-IWnPdTjhsMyH+4jhUC2EdLv3mGQ="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
 		},
 		"methods": {
-			"version": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+			"dev": true
 		},
 		"mime": {
-			"version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-			"integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
 		},
 		"mime-db": {
-			"version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-			"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"dev": true
 		},
 		"mime-types": {
-			"version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-			"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"dev": true,
 			"requires": {
-				"mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+				"mime-db": "1.40.0"
 			}
-		},
-		"minimist": {
-			"version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"ms": {
-			"version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-			"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"negotiator": {
-			"version": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-			"integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
-		},
-		"node-uuid": {
-			"version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
-			"integrity": "sha1-Oa71EOWImj3KnIlbUGxzquG6wEg="
-		},
-		"normalize-package-data": {
-			"version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-			"integrity": "sha1-SY+kIMlkAfeHQCuiHmAN75+YH/8=",
-			"requires": {
-				"hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
-				"is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-				"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-				"validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-			}
-		},
-		"number-is-nan": {
-			"version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+			"dev": true
 		},
 		"object-assign": {
-			"version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"on-finished": {
-			"version": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
-			"integrity": "sha1-XIXBzDYpn3gCllP2Z/J7a5nrwCk=",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
 			"requires": {
-				"ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+				"ee-first": "1.1.1"
 			}
 		},
-		"opn": {
-			"version": "https://registry.npmjs.org/opn/-/opn-2.0.0.tgz",
-			"integrity": "sha1-Y79FYNDeI00RP3D4tOpYElxTbag=",
+		"open": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+			"integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+			"dev": true,
 			"requires": {
-				"meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
-			}
-		},
-		"parse-json": {
-			"version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"requires": {
-				"error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+				"is-wsl": "^1.1.0"
 			}
 		},
 		"parseurl": {
-			"version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-			"integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
-		},
-		"path-exists": {
-			"version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-			"requires": {
-				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-			}
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true
 		},
 		"path-to-regexp": {
-			"version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz",
-			"integrity": "sha1-IbmrgidCed4lsVbqCP0SylG4rss="
-		},
-		"path-type": {
-			"version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"requires": {
-				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-				"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-			}
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+			"dev": true
 		},
 		"peer-ssdp": {
-			"version": "https://registry.npmjs.org/peer-ssdp/-/peer-ssdp-0.0.5.tgz",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/peer-ssdp/-/peer-ssdp-0.0.5.tgz",
 			"integrity": "sha1-G5FVuolGXszE3iy6LAOOSf3iooE="
 		},
-		"pify": {
-			"version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-		},
-		"pinkie": {
-			"version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-		},
-		"pinkie-promise": {
-			"version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"requires": {
-				"pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-			}
-		},
 		"proxy-addr": {
-			"version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
-			"integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+			"dev": true,
 			"requires": {
-				"forwarded": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-				"ipaddr.js": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+				"forwarded": "~0.1.2",
+				"ipaddr.js": "1.9.0"
 			}
 		},
 		"qs": {
-			"version": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-			"integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o="
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+			"dev": true
 		},
 		"range-parser": {
-			"version": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-			"integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"dev": true
 		},
-		"read-pkg": {
-			"version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+		"raw-body": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+			"dev": true,
 			"requires": {
-				"load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-				"normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-				"path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
 			}
 		},
-		"read-pkg-up": {
-			"version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"requires": {
-				"find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-				"read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-			}
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
-		"redent": {
-			"version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"requires": {
-				"indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-				"strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-			}
-		},
-		"repeating": {
-			"version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"requires": {
-				"is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-			}
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sax": {
-			"version": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
-			"integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk="
-		},
-		"semver": {
-			"version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"send": {
-			"version": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
-			"integrity": "sha1-zRLcWP3iHk+RkCs5sv2gWnptm9w=",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+			"dev": true,
 			"requires": {
-				"debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-				"depd": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-				"destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
-				"etag": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
-				"fresh": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
-				"mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-				"ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-				"on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
-				"range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
 			}
 		},
 		"serve-static": {
-			"version": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz",
-			"integrity": "sha1-X42gcyOtOF/z3FQfGnkXsuQ261c=",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+			"dev": true,
 			"requires": {
-				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
-				"parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-				"send": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
-				"utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
 			}
 		},
-		"signal-exit": {
-			"version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		"setprototypeof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
 		},
-		"spdx-correct": {
-			"version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-			"requires": {
-				"spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-			}
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
 		},
-		"spdx-expression-parse": {
-			"version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
-		},
-		"spdx-license-ids": {
-			"version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
-		},
-		"strip-bom": {
-			"version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"requires": {
-				"is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-			}
-		},
-		"strip-indent": {
-			"version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"requires": {
-				"get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-			}
-		},
-		"trim-newlines": {
-			"version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
 		},
 		"type-is": {
-			"version": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
-			"integrity": "sha1-4hljnBfe0coHiQkt1UoDgmuBfLI=",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"dev": true,
 			"requires": {
-				"media-typer": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-				"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
 			}
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
 		},
 		"utils-merge": {
-			"version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-			"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
 		},
-		"validate-npm-package-license": {
-			"version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-			"requires": {
-				"spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-				"spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-			}
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"vary": {
-			"version": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-			"integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"xml2js": {
-			"version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.9.tgz",
-			"integrity": "sha1-0Hz9y00gtDBHilRXvc/G7WIdiE8=",
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
 			"requires": {
-				"sax": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
-				"xmlbuilder": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
 			}
 		},
 		"xmlbuilder": {
-			"version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-			"integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
 	"main": "index",
 	"dependencies": {
 		"cors": "^2.8.5",
-		"ejs": "2.6.2",
+		"ejs": "2.7.1",
 		"gate": "^0.3.0",
 		"peer-ssdp": "0.0.5",
-		"uuid": "^3.3.2",
-		"xml2js": "0.4.19"
+		"uuid": "^3.3.3",
+		"xml2js": "0.4.21"
 	},
 	"devDependencies": {
 		"express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,16 @@
 	],
 	"main": "index",
 	"dependencies": {
+		"cors": "^2.8.5",
+		"ejs": "2.6.2",
+		"gate": "^0.3.0",
 		"peer-ssdp": "0.0.5",
-		"ejs": "2.5.7",
-		"node-uuid": "1.4.1",
-		"express": "4.12.4",
-		"opn": "2.0.0",
-		"xml2js": "0.4.9",
-		"cors": "^2.7.1",
-		"gate": "^0.3.0"
+		"uuid": "^3.3.2",
+		"xml2js": "0.4.19"
+	},
+	"devDependencies": {
+		"express": "4.17.1",
+		"open": "6.4.0"
 	},
 	"repository": "https://github.com/fraunhoferfokus/peer-dial.git"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "peer-dial",
 	"description": "Nodejs implementation of the Discovery and Launch Protocol DIAL",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"author": {
 		"name": "Louay Bassbouss",
 		"email": "louay.bassbouss@fokus.fraunhofer.de"

--- a/test/dial-server.js
+++ b/test/dial-server.js
@@ -21,7 +21,7 @@
 var dial = require("../index.js");
 var http = require('http');
 var express = require('express');
-var opn = require("opn");
+var open = require("open");
 var app = express();
 var server = http.createServer(app);
 
@@ -44,7 +44,7 @@ var apps = {
            "ex": "urn:example:org:2014"
         }*/
         launch: function (launchData) {
-            opn("http://www.youtube.com/tv?"+launchData);
+            open("http://www.youtube.com/tv?"+launchData);
         }
 	}
 };


### PR DESCRIPTION
In the couple of years this project was not maintained most of its dependencies became outdated. Old versions had several vulnerabilities which created quite a mess in npm audit.

I have updated all dependencies to their current versions.

`node-uuid` was deprecated in favor of `uuid` and `opn` in favor of `open`. No APIs used by peer-dial seem to have changed.

Additionally, I moved `express` and `open` to `devDependencies` since they are only used in test scripts and should not be installed when another module installs `peer-dial` as a dependancy.